### PR TITLE
Fix Makefile dollar sign bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,3 @@
 .PHONY: run
 run:
-	jpm run -b $(which firefox)
+	jpm run -b $$(which firefox)


### PR DESCRIPTION
Makefile assigns special meaning to dollar signs, so they need to be
escaped in order to get properly passed through to the shell when
running commands.
