### PR TITLE
Move capture to main folder

### DIFF
--- a/capture.js
+++ b/capture.js
@@ -33,9 +33,9 @@ function createGifFromImageData(data) {
     quality: 10
   });
 
-  for(int i = 0; i < data.length; i++) {
+  for(var i = 0; i < data.length; i++) {
     gif.addFrame(data[i]);
-  }
+  };
 
   gif.on('finished', function() {
     console.log('we are done creating your gif');


### PR DESCRIPTION
This is because we will get an error if not: JPM [error]   Message:
RequirementError: The `contentScriptFile` option must be a local URL or
an array of URLs.
